### PR TITLE
this may not work due to wrapping backend

### DIFF
--- a/crates/burn-backend/src/backend/base.rs
+++ b/crates/burn-backend/src/backend/base.rs
@@ -17,7 +17,7 @@ use crate::distributed::{DistributedParamId, DistributedParams};
 use super::DeviceOps;
 
 /// The mapping of types used by Backend and traits like Numeric, BasicOps
-pub trait BackendTypes {
+pub trait BackendTypes: core::fmt::Debug + Clone {
     /// Device type.
     type Device: DeviceOps;
 

--- a/crates/burn-complex/src/base.rs
+++ b/crates/burn-complex/src/base.rs
@@ -17,7 +17,7 @@ pub trait CBT: BackendTypes {
 
 /// The layout of the complex tensor. Used to define shared behavior only meant
 /// to be used for a specific layout (such as butterfly operations).
-pub trait Layout {
+pub trait Layout: alloc::fmt::Debug + Clone {
     // /// The complex Tensor primitive type for this layout. For interleaved, this will be
     // /// a tensor of Complex\<E\>,for split this will be a tuple tensor Complex\<FloatTensorPrimitive\<E\>, FloatTensorPrimitive\<E\>\>.
     // type ComplexTensorPrimitive: TensorMetadata + 'static;
@@ -119,11 +119,12 @@ pub trait ComplexTensorBackend: ComplexTensorOps<Self> + Sized + CBT {
 
 //Note: changing to adopt terminology used in fftw doc
 
+#[derive(Clone, Debug)]
 /// Indicates that the underlying implementation has separate real and imaginary tensors.
 pub struct SplitLayout {
     //_marker: core::marker::PhantomData<T>,
 }
-
+#[derive(Clone, Debug)]
 /// Indicates that the underlying implementation uses a complex primitive type \[float,float\] like that found in the
 /// num_complex trait.
 pub struct InterleavedLayout {

--- a/crates/burn-complex/src/kind.rs
+++ b/crates/burn-complex/src/kind.rs
@@ -1,4 +1,6 @@
-use crate::base::{CBT, ComplexTensor, ComplexTensorBackend};
+use crate::base::{
+    CBT, ComplexTensor, ComplexTensorBackend, InterleavedLayout, Layout, SplitLayout,
+};
 use alloc::vec::Vec;
 use burn_std::{DType, FloatDType, Shape, Slice};
 use burn_tensor::{
@@ -10,10 +12,19 @@ use burn_tensor::{
 
 /// A type-level representation of the kind of a complex tensor.
 #[derive(Clone, Debug)]
-pub struct ComplexKind;
+pub struct ComplexK<L>
+where
+    L: Layout + Clone + core::fmt::Debug,
+{
+    _marker: core::marker::PhantomData<L>,
+}
 
 #[allow(unused_variables)]
-impl<C: ComplexTensorBackend> BasicOps<C> for ComplexKind {
+impl<C, L> BasicOps<C> for ComplexK<L>
+where
+    C: ComplexTensorBackend<Layout = L>,
+    L: Layout,
+{
     type Elem = C::ComplexScalar;
 
     fn empty(shape: Shape, device: &C::Device, dtype: DType) -> Self::Primitive {
@@ -253,8 +264,10 @@ pub trait ComplexOnlyOps<C: ComplexTensorBackend> {
     fn log(self) -> C::ComplexTensorPrimitive;
 }
 
-impl<C: ComplexTensorBackend + Backend, const D: usize> ComplexOnlyOps<C>
-    for Tensor<C, D, ComplexKind>
+impl<C, const D: usize, L> ComplexOnlyOps<C> for Tensor<C, D, ComplexK<L>>
+where
+    C: ComplexTensorBackend<Layout = L>,
+    L: Layout,
 {
     fn conj(self) -> C::ComplexTensorPrimitive {
         C::conj(self.into_primitive())
@@ -266,7 +279,7 @@ impl<C: ComplexTensorBackend + Backend, const D: usize> ComplexOnlyOps<C>
     fn from_interleaved_data(
         data: TensorData,
         device: &C::Device,
-    ) -> burn_tensor::Tensor<C, D, ComplexKind> {
+    ) -> burn_tensor::Tensor<C, D, ComplexK<L>> {
         Tensor::from_primitive(C::complex_from_interleaved_data(data, device))
     }
 
@@ -313,9 +326,10 @@ impl<C: ComplexTensorBackend + Backend, const D: usize> ComplexOnlyOps<C>
 }
 
 #[allow(unused_variables)]
-impl<C: ComplexTensorBackend> Numeric<C> for ComplexKind
+impl<C, L> Numeric<C> for ComplexK<L>
 where
-    C: CBT + core::fmt::Debug + Clone,
+    C: ComplexTensorBackend<Layout = L> + CBT + core::fmt::Debug + Clone,
+    L: Layout,
 {
     type IntTensor = Int;
     fn add(lhs: Self::Primitive, rhs: Self::Primitive) -> Self::Primitive {
@@ -441,8 +455,10 @@ where
         C::complex_add(lhs, scalar_tensor)
     }
 }
+pub type ComplexKind = ComplexK<InterleavedLayout>;
+pub type SplitComplexKind = ComplexK<SplitLayout>;
 
-impl<B: ComplexTensorBackend> TensorKind<B> for ComplexKind {
+impl<B: ComplexTensorBackend> TensorKind<B> for ComplexK<B::Layout> {
     type Primitive = ComplexTensor<B>;
     fn name() -> &'static str {
         "Complex"

--- a/crates/burn-complex/src/split.rs
+++ b/crates/burn-complex/src/split.rs
@@ -112,7 +112,7 @@ impl<T: TensorMetadata + 'static> TensorMetadata for SplitComplexTensor<T> {
         }
     }
 }
-
+#[derive(Debug, Clone)]
 /// A newtype that wraps a real backend B and exposes a split-layout complex backend.
 pub struct SplitBackend<B: Backend>(core::marker::PhantomData<B>);
 impl<B: Backend> CBT for SplitBackend<B> {

--- a/crates/burn-complex/tests/common/mod.rs
+++ b/crates/burn-complex/tests/common/mod.rs
@@ -1,5 +1,6 @@
 //use burn_complex::base::split::SplitBackend;
-use burn_complex::kind::ComplexKind;
+use burn_complex::kind::{ComplexKind, SplitComplexKind};
+use burn_complex::split::SplitBackend;
 use burn_tensor::TensorData;
 use burn_tensor::{Float, Shape, Tensor, backend::Backend};
 // #[cfg(all(
@@ -8,6 +9,6 @@ use burn_tensor::{Float, Shape, Tensor, backend::Backend};
 // ))]
 
 pub type TestBackend = burn_flex::Flex;
-pub type TestTensor<const D: usize> = Tensor<TestBackend, D, ComplexKind>;
-//pub type SplitTestTensor<const D: usize> = Tensor<SplitBackend<TestBackend>, D, Float>;
+//pub type TestTensor<const D: usize> = Tensor<TestBackend, D, ComplexKind>;
+pub type TestTensor<const D: usize> = Tensor<SplitBackend<TestBackend>, D, SplitComplexKind>;
 pub type FloatTensor<const D: usize> = Tensor<TestBackend, D, Float>;

--- a/crates/burn-complex/tests/numeric.rs
+++ b/crates/burn-complex/tests/numeric.rs
@@ -3,6 +3,7 @@ mod common;
 use burn_tensor::Tolerance;
 use burn_tensor::{Complex, Distribution, Int, Tensor, TensorData};
 use common::*;
+use burn_complex::kind::ComplexOnlyOps;
 
 #[test]
 fn test_complex_add() {
@@ -20,7 +21,7 @@ fn test_complex_add() {
         &Default::default(),
     );
 
-    let tensor2 = TestTensor::<2>::from_data(
+    let tensor2 = TestTensor::<2>::from_interleaved_data(
         TensorData::from([[
             Complex::<f32> {
                 real: 5.0,

--- a/crates/burn-tensor/src/tensor/api/base.rs
+++ b/crates/burn-tensor/src/tensor/api/base.rs
@@ -2,8 +2,8 @@
 use crate::backend::ExecutionError;
 use crate::check::unwrap_shape_reshape;
 
-use burn_backend::Scalar;
 pub use burn_backend::tensor::BasicOps;
+use burn_backend::{BackendTypes, Scalar};
 
 use alloc::vec::Vec;
 
@@ -75,7 +75,7 @@ use serde::{Serialize, Serializer};
 #[derive(new, Clone, Debug)]
 pub struct Tensor<B, const D: usize, K = Float>
 where
-    B: Backend,
+    B: BackendTypes,
     K: TensorKind<B>,
 {
     pub(crate) primitive: K::Primitive,
@@ -83,7 +83,7 @@ where
 
 impl<B, const D: usize, K, T> From<T> for Tensor<B, D, K>
 where
-    B: Backend,
+    B: BackendTypes,
     K: BasicOps<B>,
     T: Into<TensorData>,
 {
@@ -94,7 +94,7 @@ where
 
 impl<B, const D: usize, K> Tensor<B, D, K>
 where
-    B: Backend,
+    B: BackendTypes,
     K: BasicOps<B>,
     K::Elem: Element,
 {
@@ -333,10 +333,10 @@ where
     ///
     /// # Example
     /// ```rust
-    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::backend::BackendTypes;
     /// use burn_tensor::Tensor;
     ///
-    /// fn example<B: Backend>() {
+    /// fn example<B: BackendTypes>() {
     ///    let device = Default::default();
     ///    let tensor = Tensor::<B, 3>::ones([2, 3, 4], &device);
     ///    // Shape { dims: [2, 3, 4] }
@@ -1680,8 +1680,8 @@ where
         let dim = dim.expect_dim_index(D);
         check!(TensorCheck::select_assign::<D>(
             dim,
-            &indices.shape(),
-            &values.shape()
+            &indices.primitive.shape(),
+            &values.primitive.shape()
         ));
 
         Self::new(K::select_assign(
@@ -1766,8 +1766,8 @@ where
     pub fn gather(self, dim: usize, indices: Tensor<B, D, Int>) -> Self {
         check!(TensorCheck::gather::<D>(
             dim,
-            &self.shape(),
-            &indices.shape()
+            &self.primitive.shape(),
+            &indices.primitive.shape()
         ));
 
         Self::new(K::gather(dim, self.primitive, indices.primitive))
@@ -1810,9 +1810,9 @@ where
     ) -> Self {
         check!(TensorCheck::scatter::<D>(
             dim,
-            &self.shape(),
-            &indices.shape(),
-            &values.shape()
+            &self.primitive.shape(),
+            &indices.primitive.shape(),
+            &values.primitive.shape()
         ));
 
         Self::new(K::scatter(
@@ -1852,9 +1852,9 @@ where
         update: IndexingUpdateOp,
     ) -> Self {
         check!(TensorCheck::scatter_nd::<D, M, DV>(
-            &self.shape(),
-            &indices.shape(),
-            &values.shape()
+            &self.primitive.shape(),
+            &indices.primitive.shape(),
+            &values.primitive.shape()
         ));
         Self::new(K::scatter_nd(
             self.primitive,
@@ -1879,7 +1879,9 @@ where
         self,
         indices: Tensor<B, M, Int>,
     ) -> Tensor<B, DV, K> {
-        check!(TensorCheck::gather_nd::<D, M, DV>(&indices.shape()));
+        check!(TensorCheck::gather_nd::<D, M, DV>(
+            &indices.primitive.shape()
+        ));
         Tensor::new(K::gather_nd(self.primitive, indices.primitive))
     }
 
@@ -2162,7 +2164,7 @@ where
     /// use burn_tensor::backend::Backend;
     /// use burn_tensor::Tensor;
     ///
-    /// fn example<B: Backend>() {
+    /// fn example<B: BackendTypes>() {
     ///     let device = Default::default();
     ///     let t1 = Tensor::<B, 2>::from_data([[3.0, 4.9, 2.0, 1.0], [2.0, 1.9, 3.0, 1.0]], &device);
     ///     let t2 = Tensor::<B, 2>::from_data([[4.0, 5.9, 8.0], [1.4, 5.8, 6.0]], &device);
@@ -2210,10 +2212,10 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::backend::BackendTypes;
     /// use burn_tensor::Tensor;
     ///
-    /// fn example<B: Backend>() {
+    /// fn example<B: BackendTypes>() {
     ///     let device = Default::default();
     ///     let t1 = Tensor::<B, 2>::from_data([[3.0, 4.9, 2.0], [2.0, 1.9, 3.0]], &device);
     ///     let t2 = Tensor::<B, 2>::from_data([[4.0, 5.9, 8.0], [1.4, 5.8, 6.0]], &device);
@@ -2780,7 +2782,7 @@ where
 /// Iterator given by (Tensor::iter_dim).
 pub struct DimIter<B, const D: usize, K>
 where
-    B: Backend,
+    B: BackendTypes,
     K: BasicOps<B>,
 {
     start: usize,
@@ -2790,7 +2792,7 @@ where
     tensor: Tensor<B, D, K>,
 }
 
-impl<B: Backend, const D: usize, K: BasicOps<B>> Iterator for DimIter<B, D, K> {
+impl<B: BackendTypes, const D: usize, K: BasicOps<B>> Iterator for DimIter<B, D, K> {
     type Item = Tensor<B, D, K>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -2808,7 +2810,7 @@ impl<B: Backend, const D: usize, K: BasicOps<B>> Iterator for DimIter<B, D, K> {
     }
 }
 
-impl<B: Backend, const D: usize, K: BasicOps<B>> DoubleEndedIterator for DimIter<B, D, K> {
+impl<B: BackendTypes, const D: usize, K: BasicOps<B>> DoubleEndedIterator for DimIter<B, D, K> {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.start >= self.end {
             return None;
@@ -2824,7 +2826,7 @@ impl<B: Backend, const D: usize, K: BasicOps<B>> DoubleEndedIterator for DimIter
     }
 }
 
-impl<B: Backend, const D: usize, K: BasicOps<B>> DimIter<B, D, K> {
+impl<B: BackendTypes, const D: usize, K: BasicOps<B>> DimIter<B, D, K> {
     fn new(tensor: Tensor<B, D, K>, dim: usize) -> Self {
         let dims = tensor.dims();
         let ranges = dims
@@ -2844,7 +2846,7 @@ impl<B: Backend, const D: usize, K: BasicOps<B>> DimIter<B, D, K> {
 
 impl<B, const D: usize, K> Tensor<B, D, K>
 where
-    B: Backend,
+    B: BackendTypes,
     K: BasicOps<B>,
     <K as BasicOps<B>>::Elem: Debug,
 {

--- a/crates/burn-tensor/src/tensor/api/check.rs
+++ b/crates/burn-tensor/src/tensor/api/check.rs
@@ -3,6 +3,7 @@ use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
+use burn_backend::BackendTypes;
 use burn_backend::tensor::Ordered;
 use burn_std::DType;
 
@@ -40,7 +41,7 @@ pub(crate) enum TensorCheck {
 
 impl TensorCheck {
     /// Checks device and shape compatibility for element wise binary operations.
-    pub(crate) fn binary_ops_ew<B: Backend, const D: usize, K: BasicOps<B>>(
+    pub(crate) fn binary_ops_ew<B: BackendTypes, const D: usize, K: BasicOps<B>>(
         ops: &str,
         lhs: &Tensor<B, D, K>,
         rhs: &Tensor<B, D, K>,
@@ -103,7 +104,7 @@ impl TensorCheck {
         check
     }
 
-    pub(crate) fn narrow<B: Backend, const D: usize, K: BasicOps<B>>(
+    pub(crate) fn narrow<B: BackendTypes, const D: usize, K: BasicOps<B>>(
         tensor: &Tensor<B, D, K>,
         dim: usize,
         start: usize,
@@ -531,7 +532,7 @@ impl TensorCheck {
         check
     }
 
-    pub(crate) fn matmul<B: Backend, const D: usize, K>(
+    pub(crate) fn matmul<B: BackendTypes, const D: usize, K>(
         lhs: &Tensor<B, D, K>,
         rhs: &Tensor<B, D, K>,
     ) -> Self
@@ -625,7 +626,7 @@ impl TensorCheck {
         check
     }
 
-    pub(crate) fn stack<B: Backend, const D1: usize, K: BasicOps<B>, const D2: usize>(
+    pub(crate) fn stack<B: BackendTypes, const D1: usize, K: BasicOps<B>, const D2: usize>(
         tensors: &[Tensor<B, D1, K>],
         dim: usize,
     ) -> Self {
@@ -679,7 +680,7 @@ impl TensorCheck {
         check
     }
 
-    pub(crate) fn cat<B: Backend, const D: usize, K: BasicOps<B>>(
+    pub(crate) fn cat<B: BackendTypes, const D: usize, K: BasicOps<B>>(
         tensors: &[Tensor<B, D, K>],
         dim: usize,
     ) -> Self {

--- a/crates/burn-tensor/src/tensor/api/numeric.rs
+++ b/crates/burn-tensor/src/tensor/api/numeric.rs
@@ -1,4 +1,4 @@
-use burn_backend::Scalar;
+use burn_backend::{BackendTypes, Scalar};
 pub use burn_backend::tensor::Numeric;
 
 use crate::alloc::borrow::ToOwned;
@@ -12,7 +12,7 @@ use crate::{IndexingUpdateOp, TensorCreationOptions};
 
 impl<B, const D: usize, K> Tensor<B, D, K>
 where
-    B: Backend,
+    B: BackendTypes,
     K: Numeric<B>,
     K::Elem: Element,
 {
@@ -665,94 +665,7 @@ where
         Self::new(K::cumprod(self.primitive, dim))
     }
 
-    /// Returns the upper triangular part of a matrix (2-D tensor) or batch of matrices input,
-    /// the other elements of the result tensor out are set to 0.
-    ///
-    /// See also [`triu_mask`](Tensor::triu_mask).
-    ///
-    /// # Arguments
-    ///
-    /// * `diagonal` - The offset from the diagonal, where 0 means the diagonal, and positive values shift
-    ///   towards the upper triangle.
-    ///
-    /// # Example
-    /// ```rust
-    /// use burn_tensor::backend::Backend;
-    /// use burn_tensor::{Int, Tensor};
-    ///
-    /// fn example<B: Backend>() {
-    ///    let device = Default::default();
-    ///    let tensor = Tensor::<B, 2, Int>::from_ints(
-    ///        [
-    ///          [1, 2, 3],
-    ///          [4, 5, 6],
-    ///          [7, 8, 9]
-    ///        ],
-    ///        &device
-    ///    );
-    ///    let tensor = tensor.triu(1);
-    ///    println!("{tensor}");
-    ///    // [
-    ///    //   [0, 2, 3],
-    ///    //   [0, 0, 6],
-    ///    //   [0, 0, 0]
-    ///    // ]
-    /// }
-    /// ```
-    pub fn triu(self, diagonal: i64) -> Self {
-        check!(TensorCheck::tri::<{ D }>());
-
-        // last two dimensions
-        let shape = &self.shape()[D - 2..].to_owned();
-
-        let mask = Tensor::<B, 2, Bool>::triu_mask(shape, diagonal, &self.device()).unsqueeze();
-        self.mask_fill(mask, 0)
-    }
-
-    /// Returns the lower triangular part of a matrix (2-D tensor) or batch of matrices input,
-    /// the other elements of the result tensor out are set to 0.
-    ///
-    /// See also [`tril_mask`](Tensor::tril_mask).
-    ///
-    /// # Arguments
-    ///
-    /// * `diagonal` - The offset from the diagonal, where 0 means the diagonal, and positive values shift
-    ///   towards the upper triangle.
-    ///
-    /// # Example
-    /// ```rust
-    /// use burn_tensor::backend::Backend;
-    /// use burn_tensor::{Int, Tensor};
-    ///
-    /// fn example<B: Backend>() {
-    ///    let device = Default::default();
-    ///    let tensor = Tensor::<B, 2, Int>::from_ints(
-    ///        [
-    ///          [1, 2, 3],
-    ///          [4, 5, 6],
-    ///          [7, 8, 9]
-    ///        ],
-    ///        &device
-    ///    );
-    ///
-    ///    let tensor = tensor.tril(-1);
-    ///    println!("{tensor}");
-    ///    // [
-    ///    //   [0, 0, 0],
-    ///    //   [4, 0, 0],
-    ///    //   [7, 8, 0]
-    ///    // ]
-    /// }
-    /// ```
-    pub fn tril(self, diagonal: i64) -> Self {
-        check!(TensorCheck::tri::<{ D }>());
-
-        // last two dimensions
-        let shape = &self.shape()[D - 2..].to_owned();
-        let mask = Tensor::<B, 2, Bool>::tril_mask(shape, diagonal, &self.device()).unsqueeze();
-
-        self.mask_fill(mask, 0)
-    }
+    
 
     /// Applies element wise power operation with a integer Tensor
     ///
@@ -911,6 +824,101 @@ where
     }
 }
 
+impl<B, const D: usize, K> Tensor<B, D, K>
+where
+    B: Backend,
+    K: Numeric<B>,
+    K::Elem: Element,
+{
+    /// Returns the upper triangular part of a matrix (2-D tensor) or batch of matrices input,
+    /// the other elements of the result tensor out are set to 0.
+    ///
+    /// See also [`triu_mask`](Tensor::triu_mask).
+    ///
+    /// # Arguments
+    ///
+    /// * `diagonal` - The offset from the diagonal, where 0 means the diagonal, and positive values shift
+    ///   towards the upper triangle.
+    ///
+    /// # Example
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::{Int, Tensor};
+    ///
+    /// fn example<B: Backend>() {
+    ///    let device = Default::default();
+    ///    let tensor = Tensor::<B, 2, Int>::from_ints(
+    ///        [
+    ///          [1, 2, 3],
+    ///          [4, 5, 6],
+    ///          [7, 8, 9]
+    ///        ],
+    ///        &device
+    ///    );
+    ///    let tensor = tensor.triu(1);
+    ///    println!("{tensor}");
+    ///    // [
+    ///    //   [0, 2, 3],
+    ///    //   [0, 0, 6],
+    ///    //   [0, 0, 0]
+    ///    // ]
+    /// }
+    /// ```
+    pub fn triu(self, diagonal: i64) -> Self {
+        check!(TensorCheck::tri::<{ D }>());
+
+        // last two dimensions
+        let shape = &self.shape()[D - 2..].to_owned();
+
+        let mask = Tensor::<B, 2, Bool>::triu_mask(shape, diagonal, &self.device()).unsqueeze();
+        self.mask_fill(mask, 0)
+    }
+
+    /// Returns the lower triangular part of a matrix (2-D tensor) or batch of matrices input,
+    /// the other elements of the result tensor out are set to 0.
+    ///
+    /// See also [`tril_mask`](Tensor::tril_mask).
+    ///
+    /// # Arguments
+    ///
+    /// * `diagonal` - The offset from the diagonal, where 0 means the diagonal, and positive values shift
+    ///   towards the upper triangle.
+    ///
+    /// # Example
+    /// ```rust
+    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::{Int, Tensor};
+    ///
+    /// fn example<B: Backend>() {
+    ///    let device = Default::default();
+    ///    let tensor = Tensor::<B, 2, Int>::from_ints(
+    ///        [
+    ///          [1, 2, 3],
+    ///          [4, 5, 6],
+    ///          [7, 8, 9]
+    ///        ],
+    ///        &device
+    ///    );
+    ///
+    ///    let tensor = tensor.tril(-1);
+    ///    println!("{tensor}");
+    ///    // [
+    ///    //   [0, 0, 0],
+    ///    //   [4, 0, 0],
+    ///    //   [7, 8, 0]
+    ///    // ]
+    /// }
+    /// ```
+    pub fn tril(self, diagonal: i64) -> Self {
+        check!(TensorCheck::tri::<{ D }>());
+
+        // last two dimensions
+        let shape = &self.shape()[D - 2..].to_owned();
+        let mask = Tensor::<B, 2, Bool>::tril_mask(shape, diagonal, &self.device()).unsqueeze();
+
+        self.mask_fill(mask, 0)
+    }
+}
 impl<B, K> Tensor<B, 1, K>
 where
     B: Backend,
@@ -998,7 +1006,7 @@ where
 macro_rules! impl_tensor_scalar_add {
     ($($t:ty),*) => {
         $(
-            impl<const D: usize, B: Backend, K: Numeric<B>> core::ops::Add<Tensor<B, D, K>> for $t
+            impl<const D: usize, B: BackendTypes, K: Numeric<B>> core::ops::Add<Tensor<B, D, K>> for $t
             where
                 K::Elem: Element,
             {
@@ -1026,7 +1034,7 @@ where
 }
 
 // Tensor - scalar
-impl<E: ElementConversion, const D: usize, B: Backend, K: Numeric<B>> core::ops::Sub<E>
+impl<E: ElementConversion, const D: usize, B: BackendTypes, K: Numeric<B>> core::ops::Sub<E>
     for Tensor<B, D, K>
 where
     K::Elem: Element,
@@ -1042,7 +1050,7 @@ where
 macro_rules! impl_tensor_scalar_sub {
     ($($t:ty),*) => {
         $(
-            impl<const D: usize, B: Backend, K: Numeric<B>> core::ops::Sub<Tensor<B, D, K>> for $t
+            impl<const D: usize, B: BackendTypes, K: Numeric<B>> core::ops::Sub<Tensor<B, D, K>> for $t
             where
                 K::Elem: Element,
             {
@@ -1058,7 +1066,7 @@ macro_rules! impl_tensor_scalar_sub {
 impl_tensor_scalar_sub!(f32, f64, i32, i64, u32, u64);
 
 // Tensor / tensor
-impl<B: Backend, const D: usize, K: Numeric<B>> core::ops::Div<Self> for Tensor<B, D, K>
+impl<B: BackendTypes, const D: usize, K: Numeric<B>> core::ops::Div<Self> for Tensor<B, D, K>
 where
     K::Elem: Element,
 {
@@ -1101,7 +1109,7 @@ macro_rules! impl_tensor_scalar_div {
 impl_tensor_scalar_div!(f32, f64);
 
 // Tensor % tensor.
-impl<const D: usize, B: Backend, K: Numeric<B>> core::ops::Rem<Self> for Tensor<B, D, K>
+impl<const D: usize, B: BackendTypes, K: Numeric<B>> core::ops::Rem<Self> for Tensor<B, D, K>
 where
     K::Elem: Element,
 {
@@ -1126,7 +1134,7 @@ where
 }
 
 // Tensor * tensor.
-impl<B: Backend, const D: usize, K: Numeric<B>> core::ops::Mul<Self> for Tensor<B, D, K>
+impl<B: BackendTypes, const D: usize, K: Numeric<B>> core::ops::Mul<Self> for Tensor<B, D, K>
 where
     K::Elem: Element,
 {
@@ -1153,7 +1161,7 @@ where
 macro_rules! impl_tensor_scalar_mul {
     ($($t:ty),*) => {
         $(
-            impl<const D: usize, B: Backend, K: Numeric<B>> core::ops::Mul<Tensor<B, D, K>> for $t
+            impl<const D: usize, B: BackendTypes, K: Numeric<B>> core::ops::Mul<Tensor<B, D, K>> for $t
             where
                 K::Elem: Element,
             {

--- a/crates/burn-tensor/src/tensor/api/options.rs
+++ b/crates/burn-tensor/src/tensor/api/options.rs
@@ -1,5 +1,5 @@
 use burn_backend::{
-    Backend, Element, get_device_settings,
+    BackendTypes, Element, get_device_settings,
     tensor::{BasicOps, Device},
 };
 use burn_std::DType;
@@ -9,7 +9,7 @@ use burn_std::DType;
 /// This struct allows specifying the `device` and overriding the data type when creating a tensor.
 /// When the `dtype` is not specified, the [device's default policy](crate::set_default_dtypes) is used.
 #[derive(Debug, Clone)]
-pub struct TensorCreationOptions<B: Backend> {
+pub struct TensorCreationOptions<B: BackendTypes> {
     /// Device where the tensor will be created.
     pub device: Device<B>,
     /// Optional data type.
@@ -17,14 +17,14 @@ pub struct TensorCreationOptions<B: Backend> {
     pub dtype: Option<DType>,
 }
 
-impl<B: Backend> Default for TensorCreationOptions<B> {
+impl<B: BackendTypes> Default for TensorCreationOptions<B> {
     /// Returns new options with the backend's default device.
     fn default() -> Self {
         Self::new(Default::default())
     }
 }
 
-impl<B: Backend> TensorCreationOptions<B> {
+impl<B: BackendTypes> TensorCreationOptions<B> {
     /// Create new options with a specific device.
     ///
     /// Data type will follow the [device policy](crate::set_default_dtypes) on tensor creation.
@@ -91,15 +91,15 @@ impl<B: Backend> TensorCreationOptions<B> {
     }
 }
 
-impl<B: Backend> From<&Device<B>> for TensorCreationOptions<B> {
+impl<B: BackendTypes> From<&Device<B>> for TensorCreationOptions<B> {
     /// Convenience conversion from a reference to a device.
     ///
     /// Example:
     /// ```rust
-    /// use burn_tensor::backend::Backend;
+    /// use burn_tensor::backend::BackendTypes;
     /// use burn_tensor::TensorCreationOptions;
     ///
-    /// fn example<B: Backend>(device: B::Device) {
+    /// fn example<B: BackendTypes>(device: B::Device) {
     ///     let options: TensorCreationOptions<B> = (&device).into();
     /// }
     /// ```
@@ -108,7 +108,7 @@ impl<B: Backend> From<&Device<B>> for TensorCreationOptions<B> {
     }
 }
 
-impl<B: Backend> From<(&Device<B>, DType)> for TensorCreationOptions<B> {
+impl<B: BackendTypes> From<(&Device<B>, DType)> for TensorCreationOptions<B> {
     /// Convenience conversion for a specified `(&device, dtype)` tuple.
     fn from(args: (&Device<B>, DType)) -> Self {
         TensorCreationOptions::new(args.0.clone()).with_dtype(args.1)

--- a/crates/burn-tensor/src/tensor/api/pad.rs
+++ b/crates/burn-tensor/src/tensor/api/pad.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use burn_backend::BackendTypes;
 use core::ops::Range;
 
 use crate::{Element, ElementConversion, Tensor, backend::Backend, ops::PadMode};
@@ -246,7 +247,7 @@ fn pad_reflect_dim<B, const D: usize, K>(
     pad_after: usize,
 ) -> Tensor<B, D, K>
 where
-    B: Backend,
+    B: BackendTypes,
     K: Numeric<B>,
     K::Elem: Element,
 {

--- a/crates/burn-vision/Cargo.toml
+++ b/crates/burn-vision/Cargo.toml
@@ -65,7 +65,7 @@ bytemuck = { workspace = true }
 cubecl = { workspace = true, optional = true }
 derive-new = { workspace = true }
 half = { workspace = true }
-image = { version = "0.25" }
+image = { workspace = true}
 macerator = { workspace = true }
 ndarray = { workspace = true }
 num-traits = { workspace = true }


### PR DESCRIPTION
So one approach I tried, may use, is to loosen the constraints on Tensor so that it's usable with things layered on top of backendTypes that may not implement backend. Right now this breaks on ops like `select_assign` since it's treating `SplitBackend<B>` as distinct from `<B>`